### PR TITLE
fix(ci): pin gh-find-current-pr to specific commit

### DIFF
--- a/.github/workflows/e2e.run.tests.yml
+++ b/.github/workflows/e2e.run.tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get PR number
         if: ${{ failure() && steps.e2e-run.conclusion == 'failure' }}
-        uses: jwalton/gh-find-current-pr@master
+        uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b
         id: pr-number
 
       - name: E2E | if tests failed, upload report


### PR DESCRIPTION
## Summary
The `Run all E2E tests` workflow [fails](https://github.com/IT4Change/boilerplate-e2e-cypress-cucumber/actions/runs/23082334873/job/67053917325) due to

```
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node22' is not supported, use 'docker', 'node12', 'node16', 'node20' or
'node24' instead.)
    at GitHub.Runner.Worker.ActionManifestManagerLegacy.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath,
MappingToken outputs)
    at GitHub.Runner.Worker.ActionManifestManagerLegacy.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load jwalton/gh-find-current-pr/master/action.yml
```

### Root Cause
The latest version of `jwalton/gh-find-current-pr@master` now
uses `node22` in its `action.yml` (the `using` field).

The GitHub runner version 2.332.0 only supports `docker`, `node12`, `node16`, `node20`, or `node24` - not `node22`.

### Fix
Pin `jwalton/gh-find-current-pr` to the latest commit hash (`89ee5799558265a1e0e31fab792ebb4ee91c016b`) before it was changed to use `node22`.

## How to test
- See the E2E tests workflow npw runs without this issue again

## Issues
- relates https://github.com/jwalton/gh-find-current-pr/issues/123
- fixes #378 #379